### PR TITLE
Make README link to fill out an issue point to creating a new issue using presentation template

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ There are a lot of talks that would be awesome for multiple meetups in Richmond,
 
 ## **Speakers**
 
-Please [fill out an issue](https://github.com/RVATechMeetups/Speakers/edit/master/.github/ISSUE_TEMPLATE/presentations.md) with information about your proposed talk. There's a template with some questions to answer about your talk within that issue. Feel free to skip any you don't feel comfortable answering. Also, add labels to the issue so your talk is easier to find.
+Please [fill out an issue](https://github.com/RVATechMeetups/Speakers/issues/new?assignees=&labels=&projects=&template=presentations.md&title=) with information about your proposed talk. There's a template with some questions to answer about your talk within that issue. Feel free to skip any you don't feel comfortable answering. Also, add labels to the issue so your talk is easier to find.
 
 ## **Organizers**
 


### PR DESCRIPTION
Hi there, I landed here from a post in Gather RVA Slack. 

The "fill out an issue" link prompts me to edit the issue template itself. The proposed change here prompts people to create a new issue populated with the presentation template, which I believe is the intention.

Please feel free to close if I've got it wrong!